### PR TITLE
fix: ensure pages have a h1 tag

### DIFF
--- a/inc/page-title.php
+++ b/inc/page-title.php
@@ -12,7 +12,7 @@
 		</ul>
 		
 	<?php elseif ( is_page() ): ?>
-		<h2><?php the_title(); ?></h2>
+		<h1><?php the_title(); ?></h1>
 
 	<?php elseif ( is_search() ): ?>
 		<h1>


### PR DESCRIPTION
search bots used to track heading tags for indexing.
this ensure a h1 title is available on pages.